### PR TITLE
Add current score command

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -593,6 +593,10 @@ def did_team_win_game(active_game, color):
     else:
         card_color = "B"
 
+    remaining_cards=count_remaining_cards(game, card_color)
+    return remaining_cards <=0
+
+def count_remaining_cards(game, card_color):
     map_card = json.loads(game.map_card) # an array of letters representing card color
     word_set = json.loads(game.word_set) # an array of random words
     target_cards = 0
@@ -606,9 +610,7 @@ def did_team_win_game(active_game, color):
         if map_card[idx_of_card] == card_color:
             actual_revealed_cards += 1
 
-    print(target_cards)
-    print(actual_revealed_cards)
-    return target_cards == actual_revealed_cards
+    return target_cards-actual_revealed_cards
 
 def give_hint(request):
     req_dict = urllib.parse.parse_qs(parse_req_body(request))
@@ -640,3 +642,19 @@ def give_hint(request):
         except:
             payload = {"replace_original": False, "text": "Your hint was improperly formatted."}
     return HttpResponse(json.dumps(payload), content_type='application/json')
+
+def current_score(request):
+    req_dict = urllib.parse.parse_qs(parse_req_body(request))
+    channel_id = req_dict['channel_id'][0]
+
+    current_game = Game.objects.get(channel_id=channel_id)
+    red_remaining=count_remaining_cards(current_game, "R")
+    blue_remaining=count_remaining_cards(current_game, "B")
+
+    payload = {
+        "replace_original": False,
+         "Text": "Red needs to find {} more cards; Blue needs to find {} more cards".format(red_remaining, blue_remaining)
+         }
+
+    return HttpResponse(json.dumps(payload), content_type='application/json')
+

--- a/app/views.py
+++ b/app/views.py
@@ -540,7 +540,7 @@ def handle_blue_spymaster_selection(active_game, channel, user, button_value):
     return payload
 
 def user_did_end_turn(active_game, user_id, response_url):
-    # enforce the user who clicked this must be a spymaster of the current team
+    # enforce the user who clicked this must not be a spymaster of the current team
     player = Player.objects.get(slack_id=user_id, game=active_game)
     active_game_filter = Game.objects.filter(id=active_game.id)
 

--- a/codenames/urls.py
+++ b/codenames/urls.py
@@ -22,4 +22,5 @@ urlpatterns = [
     url(r'^get_map_card', app.views.show_map_card),
     url(r'^give_hint', app.views.give_hint),
     url(r'^cancel_game', app.views.cancel_game),
+    url(r'^current_score', app.views.current_score),
 ]


### PR DESCRIPTION
I thought this might be helpful. We've been playing the game in Slack, and it's fun! But sometimes you want to know the current score so you know whether you have to push your luck, and the only way is to count entries on the map, which is tricky. So I added the current_score endpoint, and I changed the win condition checker so that I didn't duplicate code.

I had trouble checking the code because I couldn't quite make the right curl request to call the button endpoint, so I only tested it with a newly formed game...Is there a better way of testing this?